### PR TITLE
corrections in NDF calculation

### DIFF
--- a/KFParticle/KFParticle.cxx
+++ b/KFParticle/KFParticle.cxx
@@ -132,7 +132,7 @@ KFParticle::KFParticle(const KFPVertex& vertex) : KFParticleBase()
   vertex.GetXYZ(fP);
   vertex.GetCovarianceMatrix(fC);
   fChi2 = vertex.GetChi2();
-  fNDF = 2 * vertex.GetNContributors() - 3;
+  fNDF = vertex.GetNDF();
   fQ = 0;
   fAtProductionVertex = 0;
   fSFromDecay = 0;

--- a/KFParticle/KFParticle.h
+++ b/KFParticle/KFParticle.h
@@ -113,7 +113,7 @@ class KFParticle : public KFParticleBase
   float GetS() const;    ///< Returns dS=l/p, l - decay length, fP[7], defined if production vertex is set.
   char GetQ() const;     ///< Returns charge of the particle.
   float GetChi2() const; ///< Returns Chi2 of the fit.
-  Int_t GetNDF() const;  ///< Returns number of decrease of freedom.
+  Int_t GetNDF() const;  ///< Returns number of degrees of freedom.
 
   Bool_t GetAtProductionVertex() const { return fAtProductionVertex; } ///< Returns a flag which shows if the particle is located at the production point
   void SetAtProductionVertex(Bool_t b) { fAtProductionVertex = b; }    ///< Set a flag that particle is at the production point

--- a/KFParticle/KFParticleSIMD.cxx
+++ b/KFParticle/KFParticleSIMD.cxx
@@ -542,7 +542,7 @@ KFParticleSIMD::KFParticleSIMD(const KFPVertex& vertex) : KFParticleBaseSIMD()
     fC[i] = C[i];
   }
   fChi2 = vertex.GetChi2();
-  fNDF = 2 * vertex.GetNContributors() - 3;
+  fNDF = vertex.GetNDF();
   fQ = int_v(Vc::Zero);
   fAtProductionVertex = 0;
   fSFromDecay = 0;

--- a/KFParticle/KFParticleSIMD.h
+++ b/KFParticle/KFParticleSIMD.h
@@ -149,7 +149,7 @@ class KFParticleSIMD : public KFParticleBaseSIMD
   float_v GetS() const;    ///< Returns dS=l/p, l - decay length, fP[7], defined if production vertex is set.
   int_v GetQ() const;      ///< Returns charge of the particle.
   float_v GetChi2() const; ///< Returns Chi2 of the fit.
-  int_v GetNDF() const;    ///< Returns number of decrease of freedom.
+  int_v GetNDF() const;    ///< Returns number of degrees of freedom.
 
   Bool_t GetAtProductionVertex() const { return fAtProductionVertex; } ///< Returns a flag which shows if the particle is located at the production point
 

--- a/KFParticle/KFVertex.cxx
+++ b/KFParticle/KFVertex.cxx
@@ -32,7 +32,7 @@ KFVertex::KFVertex(const KFPVertex& vertex) : fIsConstrained(0)
   vertex.GetXYZ(fP);
   vertex.GetCovarianceMatrix(fC);
   fChi2 = vertex.GetChi2();
-  fNDF = 2 * vertex.GetNContributors() - 3;
+  fNDF = vertex.GetNDF();
   fQ = 0;
   fAtProductionVertex = 0;
   fSFromDecay = 0;


### PR DESCRIPTION
remove unnecessary calculation of vtx NDF form its NContributors and read it directly from vtx.GetNDF()